### PR TITLE
Avoid CBaseNPC extension's same native name

### DIFF
--- a/scripting/include/tf_damageinfo_tools.inc
+++ b/scripting/include/tf_damageinfo_tools.inc
@@ -4,15 +4,15 @@
 
 #define __tf_radius_damage_included
 
-methodmap CTakeDamageInfo < Handle {
-	public native CTakeDamageInfo(int inflictor, int attacker, float damage, int damagetype,
+methodmap Nosoop_CTakeDamageInfo < Handle {
+	public native Nosoop_CTakeDamageInfo(int inflictor, int attacker, float damage, int damagetype,
 			int weapon, const float damageForce[3] = NULL_VECTOR,
 			const float damagePosition[3] = NULL_VECTOR,
 			const float reportedPosition[3] = NULL_VECTOR, int damagecustom = 0);
 };
 
-methodmap CTFRadiusDamageInfo < Handle {
-	public native CTFRadiusDamageInfo(CTakeDamageInfo info, const float src[3], float radius,
+methodmap Nosoop_CTFRadiusDamageInfo < Handle {
+	public native Nosoop_CTFRadiusDamageInfo(Nosoop_CTakeDamageInfo info, const float src[3], float radius,
 			int ignoreEntity = INVALID_ENT_REFERENCE, float blastJumpRadius = 0.0,
 			float forceScale = 1.0);
 	

--- a/scripting/include/tf_damageinfo_tools.inc
+++ b/scripting/include/tf_damageinfo_tools.inc
@@ -4,15 +4,15 @@
 
 #define __tf_radius_damage_included
 
-methodmap Nosoop_CTakeDamageInfo < Handle {
-	public native Nosoop_CTakeDamageInfo(int inflictor, int attacker, float damage, int damagetype,
+methodmap TFDI_CTakeDamageInfo < Handle {
+	public native TFDI_CTakeDamageInfo(int inflictor, int attacker, float damage, int damagetype,
 			int weapon, const float damageForce[3] = NULL_VECTOR,
 			const float damagePosition[3] = NULL_VECTOR,
 			const float reportedPosition[3] = NULL_VECTOR, int damagecustom = 0);
 };
 
-methodmap Nosoop_CTFRadiusDamageInfo < Handle {
-	public native Nosoop_CTFRadiusDamageInfo(Nosoop_CTakeDamageInfo info, const float src[3], float radius,
+methodmap TFDI_CTFRadiusDamageInfo < Handle {
+	public native TFDI_CTFRadiusDamageInfo(TFDI_CTakeDamageInfo info, const float src[3], float radius,
 			int ignoreEntity = INVALID_ENT_REFERENCE, float blastJumpRadius = 0.0,
 			float forceScale = 1.0);
 	

--- a/scripting/tf_damageinfo_tools.sp
+++ b/scripting/tf_damageinfo_tools.sp
@@ -34,9 +34,9 @@ Handle g_SDKCallGameRulesRadiusDamage;
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max) {
 	RegPluginLibrary("tf2_damageinfo_tools");
 	
-	CreateNative("Nosoop_CTakeDamageInfo.Nosoop_CTakeDamageInfo", Native_TakeDamageInfoCreate);
-	CreateNative("Nosoop_CTFRadiusDamageInfo.Nosoop_CTFRadiusDamageInfo", Native_RadiusDamageInfoCreate);
-	CreateNative("Nosoop_CTFRadiusDamageInfo.Apply", Native_RadiusDamageInfoApply);
+	CreateNative("TFDI_CTakeDamageInfo.TFDI_CTakeDamageInfo", Native_TakeDamageInfoCreate);
+	CreateNative("TFDI_CTFRadiusDamageInfo.TFDI_CTFRadiusDamageInfo", Native_RadiusDamageInfoCreate);
+	CreateNative("TFDI_CTFRadiusDamageInfo.Apply", Native_RadiusDamageInfoApply);
 	
 	return APLRes_Success;
 }

--- a/scripting/tf_damageinfo_tools.sp
+++ b/scripting/tf_damageinfo_tools.sp
@@ -34,9 +34,9 @@ Handle g_SDKCallGameRulesRadiusDamage;
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max) {
 	RegPluginLibrary("tf2_damageinfo_tools");
 	
-	CreateNative("CTakeDamageInfo.CTakeDamageInfo", Native_TakeDamageInfoCreate);
-	CreateNative("CTFRadiusDamageInfo.CTFRadiusDamageInfo", Native_RadiusDamageInfoCreate);
-	CreateNative("CTFRadiusDamageInfo.Apply", Native_RadiusDamageInfoApply);
+	CreateNative("Nosoop_CTakeDamageInfo.Nosoop_CTakeDamageInfo", Native_TakeDamageInfoCreate);
+	CreateNative("Nosoop_CTFRadiusDamageInfo.Nosoop_CTFRadiusDamageInfo", Native_RadiusDamageInfoCreate);
+	CreateNative("Nosoop_CTFRadiusDamageInfo.Apply", Native_RadiusDamageInfoApply);
 	
 	return APLRes_Success;
 }


### PR DESCRIPTION
I've solved the issue. https://github.com/nosoop/SM-TFDamageInfo/issues/2
But I don't know if you like the new name.